### PR TITLE
Update rccl_helper.h

### DIFF
--- a/code/amd/rccl_helper.h
+++ b/code/amd/rccl_helper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <rccl/rccl.h>
+#include <rccl.h>
 
 // Helper function to throw std::runtime_error on rccl failures.
 void throw_rccl_error(rcclResult_t ret, int rank, int line, const char* filename) {


### PR DESCRIPTION
As per standard rccl install method in the page https://github.com/ROCmSoftwarePlatform/rccl,
"rccl.h" file is present under "/opt/rocm/rccl/include" .
There is no more "/opt/rocm/rccl/include/rccl" path where deepbench is trying to include in this file.

So, removed #include <rccl/rccl.h> to #include <rccl.h>